### PR TITLE
Start bringing code up to date, and cleanup imports

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ _testmain.go
 *.test
 *.prof
 *.json
+.idea/

--- a/engine/engine_test.go
+++ b/engine/engine_test.go
@@ -18,9 +18,9 @@ import (
 	"sync"
 	"testing"
 
-	"github.com/360EntSecGroup-Skylar/goreporter/engine/processbar"
 	"github.com/facebookgo/inject"
 	"github.com/golang/glog"
+	"goreporter/engine/processbar"
 )
 
 func Test_Engine(t *testing.T) {

--- a/engine/report2html.go
+++ b/engine/report2html.go
@@ -30,7 +30,7 @@ import (
 	"github.com/golang/glog"
 	"github.com/json-iterator/go"
 
-	"github.com/360EntSecGroup-Skylar/goreporter/utils"
+	"goreporter/utils"
 )
 
 var (
@@ -38,35 +38,36 @@ var (
 )
 
 // UnitTest is a struct that contains some features in a report of html.
-//         GoReporter HTML Report Features
 //
-//    +----------------------------------------------------------------------+
-//    |        Feature        |                 Information                  |
-//    +=======================+==============================================+
-//    | Project               | The path address of the item being detected  |
-//    +-----------------------+----------------------------------------------+
-//    | Score                 | The score of the tested project              |
-//    +-----------------------+----------------------------------------------+
-//    | CodeTest              | Unit test results                            |
-//    +-----------------------+----------------------------------------------+
-//    | IssuesNum             | Issues number of the project                 |
-//    +-----------------------+----------------------------------------------+
-//    | CodeCount             | Number of lines of code                      |
-//    +-----------------------+----------------------------------------------+
-//    | CodeStyle             | Code style check                             |
-//    +-----------------------+----------------------------------------------+
-//    | CodeOptimization      | Code optimization                            |
-//    +-----------------------+----------------------------------------------+
-//    | CodeSmell             | Code smell                                   |
-//    +-----------------------+----------------------------------------------+
-//    | DepGraph              | Depend graph of all packages in the project  |
-//    +-----------------------+----------------------------------------------+
-//    | Date                  | Date assessment of the project               |
-//    +-----------------------+----------------------------------------------+
-//    | LastRefresh           | Last refresh time of one project             |
-//    +-----------------------+----------------------------------------------+
-//    | HumanizedLastRefresh  | Humanized last refresh setting               |
-//    +-----------------------+----------------------------------------------+
+//	     GoReporter HTML Report Features
+//
+//	+----------------------------------------------------------------------+
+//	|        Feature        |                 Information                  |
+//	+=======================+==============================================+
+//	| Project               | The path address of the item being detected  |
+//	+-----------------------+----------------------------------------------+
+//	| Score                 | The score of the tested project              |
+//	+-----------------------+----------------------------------------------+
+//	| CodeTest              | Unit test results                            |
+//	+-----------------------+----------------------------------------------+
+//	| IssuesNum             | Issues number of the project                 |
+//	+-----------------------+----------------------------------------------+
+//	| CodeCount             | Number of lines of code                      |
+//	+-----------------------+----------------------------------------------+
+//	| CodeStyle             | Code style check                             |
+//	+-----------------------+----------------------------------------------+
+//	| CodeOptimization      | Code optimization                            |
+//	+-----------------------+----------------------------------------------+
+//	| CodeSmell             | Code smell                                   |
+//	+-----------------------+----------------------------------------------+
+//	| DepGraph              | Depend graph of all packages in the project  |
+//	+-----------------------+----------------------------------------------+
+//	| Date                  | Date assessment of the project               |
+//	+-----------------------+----------------------------------------------+
+//	| LastRefresh           | Last refresh time of one project             |
+//	+-----------------------+----------------------------------------------+
+//	| HumanizedLastRefresh  | Humanized last refresh setting               |
+//	+-----------------------+----------------------------------------------+
 //
 // And the HtmlData just as data for default html template. If you want to customize
 // your own template file, please follow these data, or you can redefine it yourself.

--- a/engine/reporter.go
+++ b/engine/reporter.go
@@ -26,7 +26,7 @@ import (
 	"github.com/golang/glog"
 	"github.com/json-iterator/go"
 
-	"github.com/360EntSecGroup-Skylar/goreporter/utils"
+	"goreporter/utils"
 )
 
 type Synchronizer struct {

--- a/engine/strategy_copycheck.go
+++ b/engine/strategy_copycheck.go
@@ -4,8 +4,8 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/360EntSecGroup-Skylar/goreporter/linters/copycheck"
-	"github.com/360EntSecGroup-Skylar/goreporter/utils"
+	"goreporter/linters/copycheck"
+	"goreporter/utils"
 )
 
 type StrategyCopyCheck struct {

--- a/engine/strategy_countcode.go
+++ b/engine/strategy_countcode.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"strconv"
 
-	"github.com/360EntSecGroup-Skylar/goreporter/linters/countcode"
-	"github.com/360EntSecGroup-Skylar/goreporter/utils"
+	"goreporter/linters/countcode"
+	"goreporter/utils"
 )
 
 type StrategyCountCode struct {

--- a/engine/strategy_cyclo.go
+++ b/engine/strategy_cyclo.go
@@ -5,8 +5,8 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/360EntSecGroup-Skylar/goreporter/linters/cyclo"
-	"github.com/360EntSecGroup-Skylar/goreporter/utils"
+	"goreporter/linters/cyclo"
+	"goreporter/utils"
 )
 
 type StrategyCyclo struct {

--- a/engine/strategy_deadcode.go
+++ b/engine/strategy_deadcode.go
@@ -4,8 +4,8 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/360EntSecGroup-Skylar/goreporter/linters/deadcode"
-	"github.com/360EntSecGroup-Skylar/goreporter/utils"
+	"goreporter/linters/deadcode"
+	"goreporter/utils"
 )
 
 type StrategyDeadCode struct {

--- a/engine/strategy_dependgraph.go
+++ b/engine/strategy_dependgraph.go
@@ -1,7 +1,7 @@
 package engine
 
 import (
-	"github.com/360EntSecGroup-Skylar/goreporter/linters/depend"
+	"goreporter/linters/depend"
 )
 
 type StrategyDependGraph struct {

--- a/engine/strategy_depth.go
+++ b/engine/strategy_depth.go
@@ -4,8 +4,8 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/360EntSecGroup-Skylar/goreporter/linters/depth"
-	"github.com/360EntSecGroup-Skylar/goreporter/utils"
+	"goreporter/linters/depth"
+	"goreporter/utils"
 )
 
 type StrategyDepth struct {

--- a/engine/strategy_gofmt.go
+++ b/engine/strategy_gofmt.go
@@ -3,8 +3,8 @@ package engine
 import (
 	"fmt"
 
-	"github.com/360EntSecGroup-Skylar/goreporter/linters/gofmt"
-	"github.com/360EntSecGroup-Skylar/goreporter/utils"
+	"goreporter/linters/gofmt"
+	"goreporter/utils"
 )
 
 type StrategyGoFmt struct {

--- a/engine/strategy_golint.go
+++ b/engine/strategy_golint.go
@@ -4,8 +4,8 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/360EntSecGroup-Skylar/goreporter/linters/golint"
-	"github.com/360EntSecGroup-Skylar/goreporter/utils"
+	"goreporter/linters/golint"
+	"goreporter/utils"
 )
 
 type StrategyLint struct {

--- a/engine/strategy_govet.go
+++ b/engine/strategy_govet.go
@@ -5,8 +5,8 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/360EntSecGroup-Skylar/goreporter/linters/govet"
-	"github.com/360EntSecGroup-Skylar/goreporter/utils"
+	"goreporter/linters/govet"
+	"goreporter/utils"
 )
 
 type StrategyGoVet struct {

--- a/engine/strategy_importpackages.go
+++ b/engine/strategy_importpackages.go
@@ -1,8 +1,8 @@
 package engine
 
 import (
-	"github.com/360EntSecGroup-Skylar/goreporter/linters/unittest"
-	"github.com/360EntSecGroup-Skylar/goreporter/utils"
+	"goreporter/linters/unittest"
+	"goreporter/utils"
 )
 
 type StrategyImportPackages struct {

--- a/engine/strategy_interfacer.go
+++ b/engine/strategy_interfacer.go
@@ -4,8 +4,8 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/360EntSecGroup-Skylar/goreporter/linters/interfacer"
-	"github.com/360EntSecGroup-Skylar/goreporter/utils"
+	"goreporter/linters/interfacer"
+	"goreporter/utils"
 )
 
 type StrategyInterfacer struct {

--- a/engine/strategy_simplecode.go
+++ b/engine/strategy_simplecode.go
@@ -4,8 +4,8 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/360EntSecGroup-Skylar/goreporter/linters/simplecode"
-	"github.com/360EntSecGroup-Skylar/goreporter/utils"
+	"goreporter/linters/simplecode"
+	"goreporter/utils"
 )
 
 type StrategySimpleCode struct {

--- a/engine/strategy_spellcheck.go
+++ b/engine/strategy_spellcheck.go
@@ -4,8 +4,8 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/360EntSecGroup-Skylar/goreporter/linters/spellcheck"
-	"github.com/360EntSecGroup-Skylar/goreporter/utils"
+	"goreporter/linters/spellcheck"
+	"goreporter/utils"
 )
 
 type StrategySpellCheck struct {

--- a/engine/strategy_unittest.go
+++ b/engine/strategy_unittest.go
@@ -8,8 +8,8 @@ import (
 	"github.com/golang/glog"
 	"github.com/json-iterator/go"
 
-	"github.com/360EntSecGroup-Skylar/goreporter/linters/unittest"
-	"github.com/360EntSecGroup-Skylar/goreporter/utils"
+	"goreporter/linters/unittest"
+	"goreporter/utils"
 )
 
 type StrategyUnitTest struct {

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module goreporter
+
+go 1.20

--- a/linters/copycheck/copycheck.go
+++ b/linters/copycheck/copycheck.go
@@ -9,10 +9,10 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/360EntSecGroup-Skylar/goreporter/linters/copycheck/job"
-	"github.com/360EntSecGroup-Skylar/goreporter/linters/copycheck/output"
-	"github.com/360EntSecGroup-Skylar/goreporter/linters/copycheck/syntax"
 	"github.com/golang/glog"
+	"goreporter/linters/copycheck/job"
+	"goreporter/linters/copycheck/output"
+	"goreporter/linters/copycheck/syntax"
 )
 
 const defaultThreshold = 15

--- a/linters/copycheck/job/buildtree.go
+++ b/linters/copycheck/job/buildtree.go
@@ -1,8 +1,8 @@
 package job
 
 import (
-	"github.com/360EntSecGroup-Skylar/goreporter/linters/copycheck/suffixtree"
-	"github.com/360EntSecGroup-Skylar/goreporter/linters/copycheck/syntax"
+	"goreporter/linters/copycheck/suffixtree"
+	"goreporter/linters/copycheck/syntax"
 )
 
 func BuildTree(schan chan []*syntax.Node) (t *suffixtree.STree, d *[]*syntax.Node, done chan bool) {

--- a/linters/copycheck/job/parse.go
+++ b/linters/copycheck/job/parse.go
@@ -3,8 +3,8 @@ package job
 import (
 	"log"
 
-	"github.com/360EntSecGroup-Skylar/goreporter/linters/copycheck/syntax"
-	"github.com/360EntSecGroup-Skylar/goreporter/linters/copycheck/syntax/golang"
+	"goreporter/linters/copycheck/syntax"
+	"goreporter/linters/copycheck/syntax/golang"
 )
 
 func Parse(fchan chan string) chan []*syntax.Node {

--- a/linters/copycheck/output/html.go
+++ b/linters/copycheck/output/html.go
@@ -8,7 +8,7 @@ import (
 	"regexp"
 	"sort"
 
-	"github.com/360EntSecGroup-Skylar/goreporter/linters/copycheck/syntax"
+	"goreporter/linters/copycheck/syntax"
 )
 
 type HtmlPrinter struct {

--- a/linters/copycheck/output/plumbing.go
+++ b/linters/copycheck/output/plumbing.go
@@ -5,7 +5,7 @@ import (
 	"io"
 	"sort"
 
-	"github.com/360EntSecGroup-Skylar/goreporter/linters/copycheck/syntax"
+	"goreporter/linters/copycheck/syntax"
 )
 
 type PlumbingPrinter struct {

--- a/linters/copycheck/output/text.go
+++ b/linters/copycheck/output/text.go
@@ -6,7 +6,7 @@ import (
 	"log"
 	"sort"
 
-	"github.com/360EntSecGroup-Skylar/goreporter/linters/copycheck/syntax"
+	"goreporter/linters/copycheck/syntax"
 )
 
 type FileReader interface {

--- a/linters/copycheck/syntax/golang/golang.go
+++ b/linters/copycheck/syntax/golang/golang.go
@@ -5,7 +5,7 @@ import (
 	"go/parser"
 	"go/token"
 
-	"github.com/360EntSecGroup-Skylar/goreporter/linters/copycheck/syntax"
+	"goreporter/linters/copycheck/syntax"
 )
 
 const (

--- a/linters/copycheck/syntax/syntax.go
+++ b/linters/copycheck/syntax/syntax.go
@@ -3,7 +3,7 @@ package syntax
 import (
 	"crypto/sha1"
 
-	"github.com/360EntSecGroup-Skylar/goreporter/linters/copycheck/suffixtree"
+	"goreporter/linters/copycheck/suffixtree"
 )
 
 type Node struct {

--- a/linters/countcode/countcode.go
+++ b/linters/countcode/countcode.go
@@ -8,7 +8,7 @@ import (
 	"path"
 	"strings"
 
-	"github.com/360EntSecGroup-Skylar/goreporter/utils"
+	"goreporter/utils"
 )
 
 var languages = []Language{

--- a/linters/simplecode/gosimple.go
+++ b/linters/simplecode/gosimple.go
@@ -1,4 +1,6 @@
-package simplecode // import "github.com/360EntSecGroup-Skylar/goreporter/linters/simplecode"
+// FIXME: (issue #2) investigate need for this import directive.
+// package simplecode // import "github.com/360EntSecGroup-Skylar/goreporter/linters/simplecode"
+package simplecode
 
 import (
 	"github.com/360EntSecGroup-Skylar/goreporter/linters/simplecode/lint/lintutil"

--- a/linters/simplecode/gosimple.go
+++ b/linters/simplecode/gosimple.go
@@ -3,8 +3,8 @@
 package simplecode
 
 import (
-	"github.com/360EntSecGroup-Skylar/goreporter/linters/simplecode/lint/lintutil"
-	"github.com/360EntSecGroup-Skylar/goreporter/linters/simplecode/simple"
+	"goreporter/linters/simplecode/lint/lintutil"
+	"goreporter/linters/simplecode/simple"
 )
 
 func Simple(path map[string]string, except string) []string {

--- a/linters/simplecode/lint/lint.go
+++ b/linters/simplecode/lint/lint.go
@@ -5,7 +5,9 @@
 // https://developers.google.com/open-source/licenses/bsd.
 
 // Package lint provides the foundation for tools like gosimple.
-package lint // import "github.com/360EntSecGroup-Skylar/goreporter/linters/simplecode/lint"
+// FIXME: (issue #2) investigate need for this import directive.
+// package lint // import "github.com/360EntSecGroup-Skylar/goreporter/linters/simplecode/lint"
+package lint
 
 import (
 	"bytes"

--- a/linters/simplecode/lint/lintutil/util.go
+++ b/linters/simplecode/lint/lintutil/util.go
@@ -5,7 +5,9 @@
 // https://developers.google.com/open-source/licenses/bsd.
 
 // Package lintutil provides helpers for writing linter command lines.
-package lintutil // import "github.com/360EntSecGroup-Skylar/goreporter/linters/simplecode/lint/lintutil"
+// FIXME: (issue #2) investigate need for this import directive.
+// package lintutil // import "github.com/360EntSecGroup-Skylar/goreporter/linters/simplecode/lint/lintutil"
+package lintutil
 
 import (
 	"flag"

--- a/linters/simplecode/lint/lintutil/util.go
+++ b/linters/simplecode/lint/lintutil/util.go
@@ -18,9 +18,9 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/360EntSecGroup-Skylar/goreporter/linters/simplecode/lint"
+	"goreporter/linters/simplecode/lint"
 
-	"github.com/360EntSecGroup-Skylar/goreporter/linters/simplecode/gotool"
+	"goreporter/linters/simplecode/gotool"
 )
 
 var (

--- a/linters/simplecode/lint/testutil/util.go
+++ b/linters/simplecode/lint/testutil/util.go
@@ -21,7 +21,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/360EntSecGroup-Skylar/goreporter/linters/simplecode/lint"
+	"goreporter/linters/simplecode/lint"
 )
 
 var lintMatch = flag.String("lint.match", "", "restrict testdata matches to this pattern")

--- a/linters/simplecode/lint/testutil/util.go
+++ b/linters/simplecode/lint/testutil/util.go
@@ -4,7 +4,9 @@
 // license that can be found in the LICENSE file or at
 // https://developers.google.com/open-source/licenses/bsd.
 
-package testutil // import "github.com/360EntSecGroup-Skylar/goreporter/linters/simplecode/lint/testutil"
+// FIXME: (issue #2) investigate need for this import directive.
+// package testutil // import "github.com/360EntSecGroup-Skylar/goreporter/linters/simplecode/lint/testutil"
+package testutil
 
 import (
 	"flag"

--- a/linters/simplecode/simple/lint.go
+++ b/linters/simplecode/simple/lint.go
@@ -13,7 +13,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/360EntSecGroup-Skylar/goreporter/linters/simplecode/lint"
+	"goreporter/linters/simplecode/lint"
 )
 
 var Funcs = []lint.Func{

--- a/linters/simplecode/simple/lint.go
+++ b/linters/simplecode/simple/lint.go
@@ -1,5 +1,7 @@
 // Package simple contains a linter for Go source code.
-package simple // import "github.com/360EntSecGroup-Skylar/goreporter/linters/simplecode/simple"
+// FIXME: (issue #2) investigate need for this import directive.
+// package simple // import "github.com/360EntSecGroup-Skylar/goreporter/linters/simplecode/simple"
+package simple
 
 import (
 	"go/ast"
@@ -442,12 +444,11 @@ func LintIfReturn(f *lint.File) {
 
 // LintRedundantNilCheckWithLen checks for the following reduntant nil-checks:
 //
-//   if x == nil || len(x) == 0 {}
-//   if x != nil && len(x) != 0 {}
-//   if x != nil && len(x) == N {} (where N != 0)
-//   if x != nil && len(x) > N {}
-//   if x != nil && len(x) >= N {} (where N != 0)
-//
+//	if x == nil || len(x) == 0 {}
+//	if x != nil && len(x) != 0 {}
+//	if x != nil && len(x) == N {} (where N != 0)
+//	if x != nil && len(x) > N {}
+//	if x != nil && len(x) >= N {} (where N != 0)
 func LintRedundantNilCheckWithLen(f *lint.File) {
 	isConstZero := func(expr ast.Expr) (isConst bool, isZero bool) {
 		lit, ok := expr.(*ast.BasicLit)

--- a/linters/simplecode/simple/lint_test.go
+++ b/linters/simplecode/simple/lint_test.go
@@ -3,7 +3,7 @@ package simple
 import (
 	"testing"
 
-	"github.com/360EntSecGroup-Skylar/goreporter/linters/simplecode/lint/testutil"
+	"goreporter/linters/simplecode/lint/testutil"
 )
 
 func TestAll(t *testing.T) {

--- a/linters/simpler/internal/sharedcheck/lint.go
+++ b/linters/simpler/internal/sharedcheck/lint.go
@@ -4,8 +4,8 @@ import (
 	"go/ast"
 	"go/types"
 
-	"github.com/360EntSecGroup-Skylar/goreporter/linters/simpler/lint"
-	"github.com/360EntSecGroup-Skylar/goreporter/linters/simpler/ssa"
+	"goreporter/linters/simpler/lint"
+	"goreporter/linters/simpler/ssa"
 )
 
 func CheckRangeStringRunes(nodeFns map[ast.Node]*ssa.Function, j *lint.Job) {

--- a/linters/simpler/lint.go
+++ b/linters/simpler/lint.go
@@ -1,5 +1,7 @@
 // Package simpler contains a linter for Go source code.
-package simpler // import "github.com/360EntSecGroup-Skylar/goreporter/linters/simpler"
+// FIXME: (issue #2) investigate need for this import directive.
+// package simpler // import "github.com/360EntSecGroup-Skylar/goreporter/linters/simpler"
+package simpler
 
 import (
 	"go/ast"
@@ -549,12 +551,11 @@ func (c *Checker) LintIfReturn(j *lint.Job) {
 
 // LintRedundantNilCheckWithLen checks for the following reduntant nil-checks:
 //
-//   if x == nil || len(x) == 0 {}
-//   if x != nil && len(x) != 0 {}
-//   if x != nil && len(x) == N {} (where N != 0)
-//   if x != nil && len(x) > N {}
-//   if x != nil && len(x) >= N {} (where N != 0)
-//
+//	if x == nil || len(x) == 0 {}
+//	if x != nil && len(x) != 0 {}
+//	if x != nil && len(x) == N {} (where N != 0)
+//	if x != nil && len(x) > N {}
+//	if x != nil && len(x) >= N {} (where N != 0)
 func (c *Checker) LintRedundantNilCheckWithLen(j *lint.Job) {
 	isConstZero := func(expr ast.Expr) (isConst bool, isZero bool) {
 		_, ok := expr.(*ast.BasicLit)

--- a/linters/simpler/lint.go
+++ b/linters/simpler/lint.go
@@ -13,9 +13,9 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/360EntSecGroup-Skylar/goreporter/linters/simpler/internal/sharedcheck"
-	"github.com/360EntSecGroup-Skylar/goreporter/linters/simpler/lint"
-	"github.com/360EntSecGroup-Skylar/goreporter/linters/simpler/ssa"
+	"goreporter/linters/simpler/internal/sharedcheck"
+	"goreporter/linters/simpler/lint"
+	"goreporter/linters/simpler/ssa"
 
 	"golang.org/x/tools/go/types/typeutil"
 )

--- a/linters/simpler/lint/lint.go
+++ b/linters/simpler/lint/lint.go
@@ -23,10 +23,10 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/360EntSecGroup-Skylar/goreporter/linters/simpler/ssa"
-	"github.com/360EntSecGroup-Skylar/goreporter/linters/simpler/ssa/ssautil"
 	"golang.org/x/tools/go/ast/astutil"
 	"golang.org/x/tools/go/loader"
+	"goreporter/linters/simpler/ssa"
+	"goreporter/linters/simpler/ssa/ssautil"
 )
 
 type Job struct {

--- a/linters/simpler/lint/lint.go
+++ b/linters/simpler/lint/lint.go
@@ -5,7 +5,9 @@
 // https://developers.google.com/open-source/licenses/bsd.
 
 // Package lint provides the foundation for tools like gosimple.
-package lint // import "github.com/360EntSecGroup-Skylar/goreporter/linters/simpler/lint"
+// FIXME: (issue #2) investigate need for this import directive.
+// package lint // import "github.com/360EntSecGroup-Skylar/goreporter/linters/simpler/lint"
+package lint
 
 import (
 	"bytes"

--- a/linters/simpler/lint/lintutil/util.go
+++ b/linters/simpler/lint/lintutil/util.go
@@ -22,7 +22,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/360EntSecGroup-Skylar/goreporter/linters/simpler/lint"
+	"goreporter/linters/simpler/lint"
 
 	"github.com/kisielk/gotool"
 	"golang.org/x/tools/go/loader"

--- a/linters/simpler/lint/lintutil/util.go
+++ b/linters/simpler/lint/lintutil/util.go
@@ -5,7 +5,9 @@
 // https://developers.google.com/open-source/licenses/bsd.
 
 // Package lintutil provides helpers for writing linter command lines.
-package lintutil // import "github.com/360EntSecGroup-Skylar/goreporter/linters/simpler/lint/lintutil"
+// FIXME: (issue #2) investigate need for this import directive.
+// package lintutil // import "github.com/360EntSecGroup-Skylar/goreporter/linters/simpler/lint/lintutil"
+package lintutil
 
 import (
 	"errors"

--- a/linters/simpler/lint/testutil/util.go
+++ b/linters/simpler/lint/testutil/util.go
@@ -3,8 +3,9 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file or at
 // https://developers.google.com/open-source/licenses/bsd.
-
-package testutil // import "github.com/360EntSecGroup-Skylar/goreporter/linters/simpler/lint/testutil"
+// FIXME: (issue #2) investigate need for this import directive.
+// package testutil // import "github.com/360EntSecGroup-Skylar/goreporter/linters/simpler/lint/testutil"
+package testutil
 
 import (
 	"flag"

--- a/linters/simpler/lint/testutil/util.go
+++ b/linters/simpler/lint/testutil/util.go
@@ -21,7 +21,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/360EntSecGroup-Skylar/goreporter/linters/simpler/lint"
+	"goreporter/linters/simpler/lint"
 
 	"golang.org/x/tools/go/loader"
 )

--- a/linters/simpler/lint_test.go
+++ b/linters/simpler/lint_test.go
@@ -3,7 +3,7 @@ package simpler
 import (
 	"testing"
 
-	"github.com/360EntSecGroup-Skylar/goreporter/linters/simpler/lint/testutil"
+	"goreporter/linters/simpler/lint/testutil"
 )
 
 func TestAll(t *testing.T) {

--- a/linters/simpler/simpler.go
+++ b/linters/simpler/simpler.go
@@ -1,7 +1,7 @@
 package simpler
 
 import (
-	"github.com/360EntSecGroup-Skylar/goreporter/linters/simpler/lint/lintutil"
+	"goreporter/linters/simpler/lint/lintutil"
 )
 
 func Simpler(projectPath map[string]string) []string {

--- a/linters/simpler/ssa/builder_test.go
+++ b/linters/simpler/ssa/builder_test.go
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//go:build go1.5
 // +build go1.5
 
 package ssa_test
@@ -18,9 +19,9 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/360EntSecGroup-Skylar/goreporter/linters/simpler/ssa"
-	"github.com/360EntSecGroup-Skylar/goreporter/linters/simpler/ssa/ssautil"
 	"golang.org/x/tools/go/loader"
+	"goreporter/linters/simpler/ssa"
+	"goreporter/linters/simpler/ssa/ssautil"
 )
 
 func isEmpty(f *ssa.Function) bool { return f.Blocks == nil }

--- a/linters/simpler/ssa/doc.go
+++ b/linters/simpler/ssa/doc.go
@@ -39,59 +39,59 @@
 //
 // The primary interfaces of this package are:
 //
-//    - Member: a named member of a Go package.
-//    - Value: an expression that yields a value.
-//    - Instruction: a statement that consumes values and performs computation.
-//    - Node: a Value or Instruction (emphasizing its membership in the SSA value graph)
+//   - Member: a named member of a Go package.
+//   - Value: an expression that yields a value.
+//   - Instruction: a statement that consumes values and performs computation.
+//   - Node: a Value or Instruction (emphasizing its membership in the SSA value graph)
 //
 // A computation that yields a result implements both the Value and
 // Instruction interfaces.  The following table shows for each
 // concrete type which of these interfaces it implements.
 //
-//                      Value?          Instruction?    Member?
-//   *Alloc             ✔               ✔
-//   *BinOp             ✔               ✔
-//   *Builtin           ✔
-//   *Call              ✔               ✔
-//   *ChangeInterface   ✔               ✔
-//   *ChangeType        ✔               ✔
-//   *Const             ✔
-//   *Convert           ✔               ✔
-//   *DebugRef                          ✔
-//   *Defer                             ✔
-//   *Extract           ✔               ✔
-//   *Field             ✔               ✔
-//   *FieldAddr         ✔               ✔
-//   *FreeVar           ✔
-//   *Function          ✔                               ✔ (func)
-//   *Global            ✔                               ✔ (var)
-//   *Go                                ✔
-//   *If                                ✔
-//   *Index             ✔               ✔
-//   *IndexAddr         ✔               ✔
-//   *Jump                              ✔
-//   *Lookup            ✔               ✔
-//   *MakeChan          ✔               ✔
-//   *MakeClosure       ✔               ✔
-//   *MakeInterface     ✔               ✔
-//   *MakeMap           ✔               ✔
-//   *MakeSlice         ✔               ✔
-//   *MapUpdate                         ✔
-//   *NamedConst                                        ✔ (const)
-//   *Next              ✔               ✔
-//   *Panic                             ✔
-//   *Parameter         ✔
-//   *Phi               ✔               ✔
-//   *Range             ✔               ✔
-//   *Return                            ✔
-//   *RunDefers                         ✔
-//   *Select            ✔               ✔
-//   *Send                              ✔
-//   *Slice             ✔               ✔
-//   *Store                             ✔
-//   *Type                                              ✔ (type)
-//   *TypeAssert        ✔               ✔
-//   *UnOp              ✔               ✔
+//	                   Value?          Instruction?    Member?
+//	*Alloc             ✔               ✔
+//	*BinOp             ✔               ✔
+//	*Builtin           ✔
+//	*Call              ✔               ✔
+//	*ChangeInterface   ✔               ✔
+//	*ChangeType        ✔               ✔
+//	*Const             ✔
+//	*Convert           ✔               ✔
+//	*DebugRef                          ✔
+//	*Defer                             ✔
+//	*Extract           ✔               ✔
+//	*Field             ✔               ✔
+//	*FieldAddr         ✔               ✔
+//	*FreeVar           ✔
+//	*Function          ✔                               ✔ (func)
+//	*Global            ✔                               ✔ (var)
+//	*Go                                ✔
+//	*If                                ✔
+//	*Index             ✔               ✔
+//	*IndexAddr         ✔               ✔
+//	*Jump                              ✔
+//	*Lookup            ✔               ✔
+//	*MakeChan          ✔               ✔
+//	*MakeClosure       ✔               ✔
+//	*MakeInterface     ✔               ✔
+//	*MakeMap           ✔               ✔
+//	*MakeSlice         ✔               ✔
+//	*MapUpdate                         ✔
+//	*NamedConst                                        ✔ (const)
+//	*Next              ✔               ✔
+//	*Panic                             ✔
+//	*Parameter         ✔
+//	*Phi               ✔               ✔
+//	*Range             ✔               ✔
+//	*Return                            ✔
+//	*RunDefers                         ✔
+//	*Select            ✔               ✔
+//	*Send                              ✔
+//	*Slice             ✔               ✔
+//	*Store                             ✔
+//	*Type                                              ✔ (type)
+//	*TypeAssert        ✔               ✔
+//	*UnOp              ✔               ✔
 //
 // Other key types in this package include: Program, Package, Function
 // and BasicBlock.
@@ -120,4 +120,6 @@
 // domains of source locations, ast.Nodes, types.Objects,
 // ssa.Values/Instructions.
 //
-package ssa // import "github.com/360EntSecGroup-Skylar/goreporter/linters/simpler/ssa"
+// FIXME: (issue #2) investigate need for this import directive.
+// package ssa // import "github.com/360EntSecGroup-Skylar/goreporter/linters/simpler/ssa"
+package ssa

--- a/linters/simpler/ssa/example_test.go
+++ b/linters/simpler/ssa/example_test.go
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//go:build go1.5
 // +build go1.5
 
 package ssa_test
@@ -15,9 +16,9 @@ import (
 	"go/types"
 	"os"
 
-	"github.com/360EntSecGroup-Skylar/goreporter/linters/simpler/ssa"
-	"github.com/360EntSecGroup-Skylar/goreporter/linters/simpler/ssa/ssautil"
 	"golang.org/x/tools/go/loader"
+	"goreporter/linters/simpler/ssa"
+	"goreporter/linters/simpler/ssa/ssautil"
 )
 
 const hello = `
@@ -49,7 +50,6 @@ func main() {
 // Build and run the ssadump.go program if you want a standalone tool
 // with similar functionality. It is located at
 // golang.org/x/tools/cmd/ssadump.
-//
 func ExampleBuildPackage() {
 	// Parse the source files.
 	fset := token.NewFileSet()
@@ -119,7 +119,6 @@ func ExampleBuildPackage() {
 // dependencies from source, using the loader, and then build SSA code
 // for the entire program.  This is what you'd typically use for a
 // whole-program analysis.
-//
 func ExampleLoadProgram() {
 	// Load cmd/cover and its dependencies.
 	var conf loader.Config

--- a/linters/simpler/ssa/source_test.go
+++ b/linters/simpler/ssa/source_test.go
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//go:build go1.5
 // +build go1.5
 
 package ssa_test
@@ -21,10 +22,10 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/360EntSecGroup-Skylar/goreporter/linters/simpler/ssa"
-	"github.com/360EntSecGroup-Skylar/goreporter/linters/simpler/ssa/ssautil"
 	"golang.org/x/tools/go/ast/astutil"
 	"golang.org/x/tools/go/loader"
+	"goreporter/linters/simpler/ssa"
+	"goreporter/linters/simpler/ssa/ssautil"
 )
 
 func TestObjValueLookup(t *testing.T) {
@@ -290,7 +291,6 @@ func TestValueForExpr(t *testing.T) {
 // findInterval parses input and returns the [start, end) positions of
 // the first occurrence of substr in input.  f==nil indicates failure;
 // an error has already been reported in that case.
-//
 func findInterval(t *testing.T, fset *token.FileSet, input, substr string) (f *ast.File, start, end token.Pos) {
 	f, err := parser.ParseFile(fset, "<input>", input, 0)
 	if err != nil {

--- a/linters/simpler/ssa/ssautil/load.go
+++ b/linters/simpler/ssa/ssautil/load.go
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//go:build go1.5
 // +build go1.5
 
 package ssautil
@@ -13,8 +14,8 @@ import (
 	"go/token"
 	"go/types"
 
-	"github.com/360EntSecGroup-Skylar/goreporter/linters/simpler/ssa"
 	"golang.org/x/tools/go/loader"
+	"goreporter/linters/simpler/ssa"
 )
 
 // CreateProgram returns a new program in SSA form, given a program
@@ -25,7 +26,6 @@ import (
 // on the result.
 //
 // mode controls diagnostics and checking during SSA construction.
-//
 func CreateProgram(lprog *loader.Program, mode ssa.BuilderMode) *ssa.Program {
 	prog := ssa.NewProgram(lprog.Fset, mode)
 
@@ -52,7 +52,6 @@ func CreateProgram(lprog *loader.Program, mode ssa.BuilderMode) *ssa.Program {
 // The operation fails if there were any type-checking or import errors.
 //
 // See ../ssa/example_test.go for an example.
-//
 func BuildPackage(tc *types.Config, fset *token.FileSet, pkg *types.Package, files []*ast.File, mode ssa.BuilderMode) (*ssa.Package, *types.Info, error) {
 	if fset == nil {
 		panic("no token.FileSet")

--- a/linters/simpler/ssa/ssautil/load_test.go
+++ b/linters/simpler/ssa/ssautil/load_test.go
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//go:build go1.5
 // +build go1.5
 
 package ssautil_test
@@ -15,7 +16,7 @@ import (
 	"os"
 	"testing"
 
-	"github.com/360EntSecGroup-Skylar/goreporter/linters/simpler/ssa/ssautil"
+	"goreporter/linters/simpler/ssa/ssautil"
 )
 
 const hello = `package main

--- a/linters/simpler/ssa/ssautil/switch.go
+++ b/linters/simpler/ssa/ssautil/switch.go
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//go:build go1.5
 // +build go1.5
 
 package ssautil
@@ -26,7 +27,7 @@ import (
 	"go/token"
 	"go/types"
 
-	"github.com/360EntSecGroup-Skylar/goreporter/linters/simpler/ssa"
+	"goreporter/linters/simpler/ssa"
 )
 
 // A ConstCase represents a single constant comparison.
@@ -57,7 +58,6 @@ type TypeCase struct {
 // A type switch may contain duplicate types, or types assignable
 // to an interface type also in the list.
 // TODO(adonovan): eliminate such duplicates.
-//
 type Switch struct {
 	Start      *ssa.BasicBlock // block containing start of if/else chain
 	X          ssa.Value       // the switch operand
@@ -105,7 +105,6 @@ func (sw *Switch) String() string {
 // Switches may even be inferred from if/else- or goto-based control flow.
 // (In general, the control flow constructs of the source program
 // cannot be faithfully reproduced from the SSA representation.)
-//
 func Switches(fn *ssa.Function) []Switch {
 	// Traverse the CFG in dominance order, so we don't
 	// enter an if/else-chain in the middle.
@@ -199,7 +198,6 @@ func typeSwitch(sw *Switch, y ssa.Value, T types.Type, seen map[*ssa.BasicBlock]
 
 // isComparisonBlock returns the operands (v, k) if a block ends with
 // a comparison v==k, where k is a compile-time constant.
-//
 func isComparisonBlock(b *ssa.BasicBlock) (v ssa.Value, k *ssa.Const) {
 	if n := len(b.Instrs); n >= 2 {
 		if i, ok := b.Instrs[n-1].(*ssa.If); ok {
@@ -218,7 +216,6 @@ func isComparisonBlock(b *ssa.BasicBlock) (v ssa.Value, k *ssa.Const) {
 
 // isTypeAssertBlock returns the operands (y, x, T) if a block ends with
 // a type assertion "if y, ok := x.(T); ok {".
-//
 func isTypeAssertBlock(b *ssa.BasicBlock) (y, x ssa.Value, T types.Type) {
 	if n := len(b.Instrs); n >= 4 {
 		if i, ok := b.Instrs[n-1].(*ssa.If); ok {

--- a/linters/simpler/ssa/ssautil/switch_test.go
+++ b/linters/simpler/ssa/ssautil/switch_test.go
@@ -4,6 +4,7 @@
 
 // No testdata on Android.
 
+//go:build !android
 // +build !android
 
 package ssautil_test
@@ -13,9 +14,9 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/360EntSecGroup-Skylar/goreporter/linters/simpler/ssa"
-	"github.com/360EntSecGroup-Skylar/goreporter/linters/simpler/ssa/ssautil"
 	"golang.org/x/tools/go/loader"
+	"goreporter/linters/simpler/ssa"
+	"goreporter/linters/simpler/ssa/ssautil"
 )
 
 func TestSwitches(t *testing.T) {

--- a/linters/simpler/ssa/ssautil/visit.go
+++ b/linters/simpler/ssa/ssautil/visit.go
@@ -1,8 +1,9 @@
 // Copyright 2013 The Go Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
-
-package ssautil // import "github.com/360EntSecGroup-Skylar/goreporter/linters/simpler/ssa/ssautil"
+// FIXME: (issue #2) investigate need for this import directive.
+// package ssautil // import "github.com/360EntSecGroup-Skylar/goreporter/linters/simpler/ssa/ssautil"
+package ssautil
 
 import "github.com/360EntSecGroup-Skylar/goreporter/linters/simpler/ssa"
 
@@ -18,7 +19,6 @@ import "github.com/360EntSecGroup-Skylar/goreporter/linters/simpler/ssa"
 // synthetic wrappers.
 //
 // Precondition: all packages are built.
-//
 func AllFunctions(prog *ssa.Program) map[*ssa.Function]bool {
 	visit := visitor{
 		prog: prog,

--- a/linters/simpler/ssa/ssautil/visit.go
+++ b/linters/simpler/ssa/ssautil/visit.go
@@ -5,7 +5,7 @@
 // package ssautil // import "github.com/360EntSecGroup-Skylar/goreporter/linters/simpler/ssa/ssautil"
 package ssautil
 
-import "github.com/360EntSecGroup-Skylar/goreporter/linters/simpler/ssa"
+import "goreporter/linters/simpler/ssa"
 
 // This file defines utilities for visiting the SSA representation of
 // a Program.

--- a/linters/simpler/ssa/stdlib_test.go
+++ b/linters/simpler/ssa/stdlib_test.go
@@ -4,6 +4,7 @@
 
 // Incomplete source tree on Android.
 
+//go:build !android
 // +build !android
 
 package ssa_test
@@ -21,10 +22,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/360EntSecGroup-Skylar/goreporter/linters/simpler/ssa"
-	"github.com/360EntSecGroup-Skylar/goreporter/linters/simpler/ssa/ssautil"
 	"golang.org/x/tools/go/buildutil"
 	"golang.org/x/tools/go/loader"
+	"goreporter/linters/simpler/ssa"
+	"goreporter/linters/simpler/ssa/ssautil"
 )
 
 // Skip the set of packages that transitively depend on

--- a/linters/simpler/ssa/testmain_test.go
+++ b/linters/simpler/ssa/testmain_test.go
@@ -12,9 +12,9 @@ import (
 	"sort"
 	"testing"
 
-	"github.com/360EntSecGroup-Skylar/goreporter/linters/simpler/ssa"
-	"github.com/360EntSecGroup-Skylar/goreporter/linters/simpler/ssa/ssautil"
 	"golang.org/x/tools/go/loader"
+	"goreporter/linters/simpler/ssa"
+	"goreporter/linters/simpler/ssa/ssautil"
 )
 
 func create(t *testing.T, content string) *ssa.Package {

--- a/linters/spellcheck/spellcheck.go
+++ b/linters/spellcheck/spellcheck.go
@@ -12,7 +12,7 @@ import (
 	"text/template"
 	"time"
 
-	"github.com/360EntSecGroup-Skylar/goreporter/linters/spellcheck/misspell"
+	"goreporter/linters/spellcheck/misspell"
 )
 
 var (

--- a/linters/staticcheck/callgraph/callgraph.go
+++ b/linters/staticcheck/callgraph/callgraph.go
@@ -32,7 +32,9 @@ in the call graph; they are treated like built-in operators of the
 language.
 
 */
-package callgraph // import "github.com/360EntSecGroup-Skylar/goreporter/linters/staticcheck/callgraph"
+// FIXME: (issue #2) investigate need for this import directive.
+// package callgraph // import "github.com/360EntSecGroup-Skylar/goreporter/linters/staticcheck/callgraph"
+package callgraph
 
 // TODO(adonovan): add a function to eliminate wrappers from the
 // callgraph, preserving topology.
@@ -51,7 +53,6 @@ import (
 // A graph may contain nodes that are not reachable from the root.
 // If the call graph is sound, such nodes indicate unreachable
 // functions.
-//
 type Graph struct {
 	Root  *Node                   // the distinguished root node
 	Nodes map[*ssa.Function]*Node // all nodes by function

--- a/linters/staticcheck/callgraph/callgraph.go
+++ b/linters/staticcheck/callgraph/callgraph.go
@@ -45,7 +45,7 @@ import (
 	"fmt"
 	"go/token"
 
-	"github.com/360EntSecGroup-Skylar/goreporter/linters/simpler/ssa"
+	"goreporter/linters/simpler/ssa"
 )
 
 // A Graph represents a call graph.

--- a/linters/staticcheck/callgraph/cha/cha.go
+++ b/linters/staticcheck/callgraph/cha/cha.go
@@ -21,7 +21,10 @@
 // and all concrete types are put into interfaces, it is sound to run on
 // partial programs, such as libraries without a main or test function.
 //
-package cha // import "github.com/360EntSecGroup-Skylar/goreporter/linters/staticcheck/callgraph/cha"
+// FIXME: (issue #2) investigate need for this import directive.
+// package cha // import "github.com/360EntSecGroup-Skylar/goreporter/linters/staticcheck/callgraph/cha"
+
+package cha
 
 import (
 	"go/types"
@@ -34,7 +37,6 @@ import (
 
 // CallGraph computes the call graph of the specified program using the
 // Class Hierarchy Analysis algorithm.
-//
 func CallGraph(prog *ssa.Program) *callgraph.Graph {
 	cg := callgraph.New(nil) // TODO(adonovan) eliminate concept of rooted callgraph
 

--- a/linters/staticcheck/callgraph/cha/cha.go
+++ b/linters/staticcheck/callgraph/cha/cha.go
@@ -29,10 +29,10 @@ package cha
 import (
 	"go/types"
 
-	"github.com/360EntSecGroup-Skylar/goreporter/linters/simpler/ssa"
-	"github.com/360EntSecGroup-Skylar/goreporter/linters/simpler/ssa/ssautil"
-	"github.com/360EntSecGroup-Skylar/goreporter/linters/staticcheck/callgraph"
 	"golang.org/x/tools/go/types/typeutil"
+	"goreporter/linters/simpler/ssa"
+	"goreporter/linters/simpler/ssa/ssautil"
+	"goreporter/linters/staticcheck/callgraph"
 )
 
 // CallGraph computes the call graph of the specified program using the

--- a/linters/staticcheck/callgraph/cha/cha_test.go
+++ b/linters/staticcheck/callgraph/cha/cha_test.go
@@ -4,6 +4,7 @@
 
 // No testdata on Android.
 
+//go:build !android
 // +build !android
 
 package cha_test
@@ -20,10 +21,10 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/360EntSecGroup-Skylar/goreporter/linters/simpler/ssa/ssautil"
-	"github.com/360EntSecGroup-Skylar/goreporter/linters/staticcheck/callgraph"
-	"github.com/360EntSecGroup-Skylar/goreporter/linters/staticcheck/callgraph/cha"
 	"golang.org/x/tools/go/loader"
+	"goreporter/linters/simpler/ssa/ssautil"
+	"goreporter/linters/staticcheck/callgraph"
+	"goreporter/linters/staticcheck/callgraph/cha"
 )
 
 var inputs = []string{
@@ -45,7 +46,6 @@ func expectation(f *ast.File) (string, token.Pos) {
 // TestCHA runs CHA on each file in inputs, prints the dynamic edges of
 // the call graph, and compares it with the golden results embedded in
 // the WANT comment at the end of the file.
-//
 func TestCHA(t *testing.T) {
 	for _, filename := range inputs {
 		content, err := ioutil.ReadFile(filename)

--- a/linters/staticcheck/callgraph/rta/rta.go
+++ b/linters/staticcheck/callgraph/rta/rta.go
@@ -40,7 +40,9 @@
 // cmd/callgraph tool on its own source takes ~2.1s for RTA and ~5.4s
 // for points-to analysis.
 //
-package rta // import "github.com/360EntSecGroup-Skylar/goreporter/linters/staticcheck/callgraph/rta"
+// FIXME: (issue #2) investigate need for this import directive.
+// package rta // import "github.com/360EntSecGroup-Skylar/goreporter/linters/staticcheck/callgraph/rta"
+package rta
 
 // TODO(adonovan): test it by connecting it to the interpreter and
 // replacing all "unreachable" functions by a special intrinsic, and
@@ -57,7 +59,6 @@ import (
 
 // A Result holds the results of Rapid Type Analysis, which includes the
 // set of reachable functions/methods, runtime types, and the call graph.
-//
 type Result struct {
 	// CallGraph is the discovered callgraph.
 	// It does not include edges for calls made via reflection.
@@ -262,7 +263,6 @@ func (r *rta) visitFunc(f *ssa.Function) {
 // If buildCallGraph is true, Result.CallGraph will contain a call
 // graph; otherwise, only the other fields (reachable functions) are
 // populated.
-//
 func Analyze(roots []*ssa.Function, buildCallGraph bool) *Result {
 	if len(roots) == 0 {
 		return nil
@@ -341,7 +341,6 @@ func (r *rta) implementations(I *types.Interface) []types.Type {
 // addRuntimeType is called for each concrete type that can be the
 // dynamic type of some interface or reflect.Value.
 // Adapted from needMethods in go/ssa/builder.go
-//
 func (r *rta) addRuntimeType(T types.Type, skip bool) {
 	if prev, ok := r.result.RuntimeTypes.At(T).(bool); ok {
 		if skip && !prev {

--- a/linters/staticcheck/callgraph/rta/rta.go
+++ b/linters/staticcheck/callgraph/rta/rta.go
@@ -52,9 +52,9 @@ import (
 	"fmt"
 	"go/types"
 
-	"github.com/360EntSecGroup-Skylar/goreporter/linters/simpler/ssa"
-	"github.com/360EntSecGroup-Skylar/goreporter/linters/staticcheck/callgraph"
 	"golang.org/x/tools/go/types/typeutil"
+	"goreporter/linters/simpler/ssa"
+	"goreporter/linters/staticcheck/callgraph"
 )
 
 // A Result holds the results of Rapid Type Analysis, which includes the

--- a/linters/staticcheck/callgraph/rta/rta_test.go
+++ b/linters/staticcheck/callgraph/rta/rta_test.go
@@ -4,6 +4,7 @@
 
 // No testdata on Android.
 
+//go:build !android
 // +build !android
 
 package rta_test
@@ -20,11 +21,11 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/360EntSecGroup-Skylar/goreporter/linters/simpler/ssa"
-	"github.com/360EntSecGroup-Skylar/goreporter/linters/simpler/ssa/ssautil"
-	"github.com/360EntSecGroup-Skylar/goreporter/linters/staticcheck/callgraph"
-	"github.com/360EntSecGroup-Skylar/goreporter/linters/staticcheck/callgraph/rta"
 	"golang.org/x/tools/go/loader"
+	"goreporter/linters/simpler/ssa"
+	"goreporter/linters/simpler/ssa/ssautil"
+	"goreporter/linters/staticcheck/callgraph"
+	"goreporter/linters/staticcheck/callgraph/rta"
 )
 
 var inputs = []string{
@@ -50,7 +51,6 @@ func expectation(f *ast.File) (string, token.Pos) {
 // The results string consists of two parts: the set of dynamic call
 // edges, "f --> g", one per line, and the set of reachable functions,
 // one per line.  Each set is sorted.
-//
 func TestRTA(t *testing.T) {
 	for _, filename := range inputs {
 		content, err := ioutil.ReadFile(filename)

--- a/linters/staticcheck/callgraph/static/static.go
+++ b/linters/staticcheck/callgraph/static/static.go
@@ -5,9 +5,9 @@
 package static
 
 import (
-	"github.com/360EntSecGroup-Skylar/goreporter/linters/simpler/ssa"
-	"github.com/360EntSecGroup-Skylar/goreporter/linters/simpler/ssa/ssautil"
-	"github.com/360EntSecGroup-Skylar/goreporter/linters/staticcheck/callgraph"
+	"goreporter/linters/simpler/ssa"
+	"goreporter/linters/simpler/ssa/ssautil"
+	"goreporter/linters/staticcheck/callgraph"
 )
 
 // CallGraph computes the call graph of the specified program

--- a/linters/staticcheck/callgraph/static/static.go
+++ b/linters/staticcheck/callgraph/static/static.go
@@ -1,6 +1,8 @@
 // Package static computes the call graph of a Go program containing
 // only static call edges.
-package static // import "github.com/360EntSecGroup-Skylar/goreporter/linters/staticcheck/callgraph/static"
+// FIXME: (issue #2) investigate need for this import directive.
+// package static // import "github.com/360EntSecGroup-Skylar/goreporter/linters/staticcheck/callgraph/static"
+package static
 
 import (
 	"github.com/360EntSecGroup-Skylar/goreporter/linters/simpler/ssa"
@@ -10,7 +12,6 @@ import (
 
 // CallGraph computes the call graph of the specified program
 // considering only static calls.
-//
 func CallGraph(prog *ssa.Program) *callgraph.Graph {
 	cg := callgraph.New(nil) // TODO(adonovan) eliminate concept of rooted callgraph
 

--- a/linters/staticcheck/callgraph/static/static_test.go
+++ b/linters/staticcheck/callgraph/static/static_test.go
@@ -11,10 +11,10 @@ import (
 	"sort"
 	"testing"
 
-	"github.com/360EntSecGroup-Skylar/goreporter/linters/simpler/ssa/ssautil"
-	"github.com/360EntSecGroup-Skylar/goreporter/linters/staticcheck/callgraph"
-	"github.com/360EntSecGroup-Skylar/goreporter/linters/staticcheck/callgraph/static"
 	"golang.org/x/tools/go/loader"
+	"goreporter/linters/simpler/ssa/ssautil"
+	"goreporter/linters/staticcheck/callgraph"
+	"goreporter/linters/staticcheck/callgraph/static"
 )
 
 const input = `package P

--- a/linters/staticcheck/callgraph/util.go
+++ b/linters/staticcheck/callgraph/util.go
@@ -4,14 +4,13 @@
 
 package callgraph
 
-import "github.com/360EntSecGroup-Skylar/goreporter/linters/simpler/ssa"
+import "goreporter/linters/simpler/ssa"
 
 // This file provides various utilities over call graphs, such as
 // visitation and path search.
 
 // CalleesOf returns a new set containing all direct callees of the
 // caller node.
-//
 func CalleesOf(caller *Node) map[*Node]bool {
 	callees := make(map[*Node]bool)
 	for _, e := range caller.Out {
@@ -24,7 +23,6 @@ func CalleesOf(caller *Node) map[*Node]bool {
 // The edge function is called for each edge in postorder.  If it
 // returns non-nil, visitation stops and GraphVisitEdges returns that
 // value.
-//
 func GraphVisitEdges(g *Graph, edge func(*Edge) error) error {
 	seen := make(map[*Node]bool)
 	var visit func(n *Node) error
@@ -54,7 +52,6 @@ func GraphVisitEdges(g *Graph, edge func(*Edge) error) error {
 // ending at some node for which isEnd() returns true.  On success,
 // PathSearch returns the path as an ordered list of edges; on
 // failure, it returns nil.
-//
 func PathSearch(start *Node, isEnd func(*Node) bool) []*Edge {
 	stack := make([]*Edge, 0, 32)
 	seen := make(map[*Node]bool)
@@ -82,7 +79,6 @@ func PathSearch(start *Node, isEnd func(*Node) bool) []*Edge {
 // synthetic functions (except g.Root and package initializers),
 // preserving the topology.  In effect, calls to synthetic wrappers
 // are "inlined".
-//
 func (g *Graph) DeleteSyntheticNodes() {
 	// Measurements on the standard library and go.tools show that
 	// resulting graph has ~15% fewer nodes and 4-8% fewer edges

--- a/linters/staticcheck/functions/concrete.go
+++ b/linters/staticcheck/functions/concrete.go
@@ -4,7 +4,7 @@ import (
 	"go/token"
 	"go/types"
 
-	"github.com/360EntSecGroup-Skylar/goreporter/linters/simpler/ssa"
+	"goreporter/linters/simpler/ssa"
 )
 
 func concreteReturnTypes(fn *ssa.Function) []*types.Tuple {

--- a/linters/staticcheck/functions/functions.go
+++ b/linters/staticcheck/functions/functions.go
@@ -4,10 +4,10 @@ import (
 	"go/types"
 	"sync"
 
-	"github.com/360EntSecGroup-Skylar/goreporter/linters/simpler/ssa"
-	"github.com/360EntSecGroup-Skylar/goreporter/linters/staticcheck/callgraph"
-	"github.com/360EntSecGroup-Skylar/goreporter/linters/staticcheck/callgraph/static"
-	"github.com/360EntSecGroup-Skylar/goreporter/linters/staticcheck/vrp"
+	"goreporter/linters/simpler/ssa"
+	"goreporter/linters/staticcheck/callgraph"
+	"goreporter/linters/staticcheck/callgraph/static"
+	"goreporter/linters/staticcheck/vrp"
 )
 
 var stdlibDescs = map[string]Description{

--- a/linters/staticcheck/functions/loops.go
+++ b/linters/staticcheck/functions/loops.go
@@ -1,6 +1,6 @@
 package functions
 
-import "github.com/360EntSecGroup-Skylar/goreporter/linters/simpler/ssa"
+import "goreporter/linters/simpler/ssa"
 
 type Loop map[*ssa.BasicBlock]bool
 

--- a/linters/staticcheck/functions/pure.go
+++ b/linters/staticcheck/functions/pure.go
@@ -4,8 +4,8 @@ import (
 	"go/token"
 	"go/types"
 
-	"github.com/360EntSecGroup-Skylar/goreporter/linters/simpler/ssa"
-	"github.com/360EntSecGroup-Skylar/goreporter/linters/staticcheck/callgraph"
+	"goreporter/linters/simpler/ssa"
+	"goreporter/linters/staticcheck/callgraph"
 )
 
 func (d *Descriptions) IsPure(fn *ssa.Function) bool {

--- a/linters/staticcheck/functions/terminates.go
+++ b/linters/staticcheck/functions/terminates.go
@@ -1,6 +1,6 @@
 package functions
 
-import "github.com/360EntSecGroup-Skylar/goreporter/linters/simpler/ssa"
+import "goreporter/linters/simpler/ssa"
 
 // terminates reports whether fn is supposed to return, that is if it
 // has at least one theoretic path that returns from the function.

--- a/linters/staticcheck/gcsizes/sizes.go
+++ b/linters/staticcheck/gcsizes/sizes.go
@@ -4,7 +4,9 @@
 
 // Package gcsizes provides a types.Sizes implementation that adheres
 // to the rules used by the gc compiler.
-package gcsizes // import "github.com/360EntSecGroup-Skylar/goreporter/linters/staticcheck/gcsizes"
+// FIXME: (issue #2) investigate need for this import directive.
+// package gcsizes // import "github.com/360EntSecGroup-Skylar/goreporter/linters/staticcheck/gcsizes"
+package gcsizes
 
 import (
 	"go/build"

--- a/linters/staticcheck/internal/sharedcheck/lint.go
+++ b/linters/staticcheck/internal/sharedcheck/lint.go
@@ -4,8 +4,8 @@ import (
 	"go/ast"
 	"go/types"
 
-	"github.com/360EntSecGroup-Skylar/goreporter/linters/simpler/lint"
-	"github.com/360EntSecGroup-Skylar/goreporter/linters/simpler/ssa"
+	"goreporter/linters/simpler/lint"
+	"goreporter/linters/simpler/ssa"
 )
 
 func CheckRangeStringRunes(nodeFns map[ast.Node]*ssa.Function, j *lint.Job) {

--- a/linters/staticcheck/lint.go
+++ b/linters/staticcheck/lint.go
@@ -18,12 +18,12 @@ import (
 	"sync"
 	texttemplate "text/template"
 
-	"github.com/360EntSecGroup-Skylar/goreporter/linters/simpler/lint"
-	"github.com/360EntSecGroup-Skylar/goreporter/linters/simpler/ssa"
-	"github.com/360EntSecGroup-Skylar/goreporter/linters/staticcheck/functions"
-	"github.com/360EntSecGroup-Skylar/goreporter/linters/staticcheck/gcsizes"
-	"github.com/360EntSecGroup-Skylar/goreporter/linters/staticcheck/internal/sharedcheck"
-	"github.com/360EntSecGroup-Skylar/goreporter/linters/staticcheck/vrp"
+	"goreporter/linters/simpler/lint"
+	"goreporter/linters/simpler/ssa"
+	"goreporter/linters/staticcheck/functions"
+	"goreporter/linters/staticcheck/gcsizes"
+	"goreporter/linters/staticcheck/internal/sharedcheck"
+	"goreporter/linters/staticcheck/vrp"
 
 	"golang.org/x/tools/go/ast/astutil"
 )

--- a/linters/staticcheck/lint.go
+++ b/linters/staticcheck/lint.go
@@ -1,5 +1,7 @@
 // Package staticcheck contains a linter for Go source code.
-package staticcheck // import "github.com/360EntSecGroup-Skylar/goreporter/linters/staticcheck"
+// FIXME: (issue #2) investigate need for this import directive.
+// package staticcheck // import "github.com/360EntSecGroup-Skylar/goreporter/linters/staticcheck"
+package staticcheck
 
 import (
 	"fmt"

--- a/linters/staticcheck/lint_test.go
+++ b/linters/staticcheck/lint_test.go
@@ -3,8 +3,8 @@ package staticcheck
 import (
 	"testing"
 
-	"github.com/360EntSecGroup-Skylar/goreporter/linters/simpler/lint/lintutil"
-	"github.com/360EntSecGroup-Skylar/goreporter/linters/simpler/lint/testutil"
+	"goreporter/linters/simpler/lint/lintutil"
+	"goreporter/linters/simpler/lint/testutil"
 )
 
 func TestAll(t *testing.T) {

--- a/linters/staticcheck/rules.go
+++ b/linters/staticcheck/rules.go
@@ -13,9 +13,9 @@ import (
 	"time"
 	"unicode/utf8"
 
-	"github.com/360EntSecGroup-Skylar/goreporter/linters/simpler/lint"
-	"github.com/360EntSecGroup-Skylar/goreporter/linters/simpler/ssa"
-	"github.com/360EntSecGroup-Skylar/goreporter/linters/staticcheck/vrp"
+	"goreporter/linters/simpler/lint"
+	"goreporter/linters/simpler/ssa"
+	"goreporter/linters/staticcheck/vrp"
 )
 
 const (

--- a/linters/staticcheck/staticcheck.go
+++ b/linters/staticcheck/staticcheck.go
@@ -1,7 +1,7 @@
 package staticcheck
 
 import (
-	"github.com/360EntSecGroup-Skylar/goreporter/linters/simpler/lint/lintutil"
+	"goreporter/linters/simpler/lint/lintutil"
 )
 
 func StaticCheck(projectPath map[string]string) []string {

--- a/linters/staticcheck/vrp/channel.go
+++ b/linters/staticcheck/vrp/channel.go
@@ -3,7 +3,7 @@ package vrp
 import (
 	"fmt"
 
-	"github.com/360EntSecGroup-Skylar/goreporter/linters/simpler/ssa"
+	"goreporter/linters/simpler/ssa"
 )
 
 type ChannelInterval struct {

--- a/linters/staticcheck/vrp/int.go
+++ b/linters/staticcheck/vrp/int.go
@@ -6,7 +6,7 @@ import (
 	"go/types"
 	"math/big"
 
-	"github.com/360EntSecGroup-Skylar/goreporter/linters/simpler/ssa"
+	"goreporter/linters/simpler/ssa"
 )
 
 type Zs []Z

--- a/linters/staticcheck/vrp/slice.go
+++ b/linters/staticcheck/vrp/slice.go
@@ -7,7 +7,7 @@ import (
 	"fmt"
 	"go/types"
 
-	"github.com/360EntSecGroup-Skylar/goreporter/linters/simpler/ssa"
+	"goreporter/linters/simpler/ssa"
 )
 
 type SliceInterval struct {

--- a/linters/staticcheck/vrp/string.go
+++ b/linters/staticcheck/vrp/string.go
@@ -5,7 +5,7 @@ import (
 	"go/token"
 	"go/types"
 
-	"github.com/360EntSecGroup-Skylar/goreporter/linters/simpler/ssa"
+	"goreporter/linters/simpler/ssa"
 )
 
 type StringInterval struct {

--- a/linters/staticcheck/vrp/vrp.go
+++ b/linters/staticcheck/vrp/vrp.go
@@ -12,7 +12,7 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/360EntSecGroup-Skylar/goreporter/linters/simpler/ssa"
+	"goreporter/linters/simpler/ssa"
 )
 
 type Future interface {

--- a/main.go
+++ b/main.go
@@ -27,9 +27,9 @@ import (
 	"sync"
 	"time"
 
-	"github.com/360EntSecGroup-Skylar/goreporter/engine"
-	"github.com/360EntSecGroup-Skylar/goreporter/engine/processbar"
 	"github.com/facebookgo/inject"
+	"goreporter/engine"
+	"goreporter/engine/processbar"
 )
 
 // Received parameters, you can control some features using:


### PR DESCRIPTION
Start bringing the code up to modern Go (1.20).

Cleanup references to local files to remote ones.